### PR TITLE
readme: mention pipx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,12 @@ Install the plugin by poetry plugin command.
 
     poetry self add poetry-bumpversion
 
+If you're using pipx, use this command instead.
+
+::
+
+    pipx inject poetry poetry-bumpversion
+
 ++++++++++++++++++++++++++++++
 Configure version replacements
 ++++++++++++++++++++++++++++++


### PR DESCRIPTION
- update readme with pipx directions

The normal installation command fails if poetry is installed via pipx. This worked for me. 

More details: https://python-poetry.org/docs/plugins/#with-pipx-inject
